### PR TITLE
feat: split_merge macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rusty_chain"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "deadqueue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +344,7 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "deadqueue",
+ "futures",
  "paste",
  "tokio",
 ]
@@ -266,6 +362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["concurrency", "data-structures"]
 paste = "1.0.13"
 deadqueue = { version = "0.2.4", features = ["unlimited"] }
 async-trait = "0.1.71"
+futures = "0.3.28"
 
 [dev-dependencies]
 tokio = { version = "1.29.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ paste = "1.0.13"
 deadqueue = { version = "0.2.4", features = ["unlimited"] }
 async-trait = "0.1.71"
 futures = "0.3.28"
+tokio = { version = "1.29.1", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "1.29.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_chain"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Austin Heller"]
 description = "This library abstracts over functional processing units called `chain links`. Each link in the chain is meant to be independent, immutable, idempotent, and highly testable."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rusty Chain
-This library abstracts over functional processing units called `ChainLink`s and `Chain`s. Each link in the chain is meant to be independent, immutable, idempotent, and highly testable.
+This library abstracts over functional processing units called `ChainLink`s and `Chain`s. Each link in the chain is meant to be independent, immutable, idempotent, parallelizable, and highly testable.
 
 ## Features
 
@@ -7,6 +7,7 @@ This library abstracts over functional processing units called `ChainLink`s and 
   - By using the `chain_link!` macro you can quickly construct the internals of the mapping from input to output.
 - A `Chain` is a concatenation of `ChainLink`s (and other `Chain`s) and is a natural extension of this methodology for processing.
   - By using the `chain!` macro you can concatenate both `ChainLink`s and `Chain`s naturally.
+- A `split_merge!` macro permits parallel processing multiple `ChainLink` implementations, round-robin iterating over them per `send`.
 
 ## Usage
 
@@ -26,7 +27,7 @@ I have always wanted highly testable code and to work in an environment where th
 
 ## Future work
 
-- Split
+- split_merge! conditions
   - This would allow the `send` from one `ChainLink` to make its way to different destination `ChainLink`s based on a conditional block per destination, allowing logical, asynchronous splitting of processing.
-- Merge
-  - This would form a bottleneck of processing, allowing the zippering of received input into the next `ChainLink`.
+- split_merge! more efficient round-robin
+  - If the current parallel `ChainLink` returned `None`, try all of the others (in order) until either all of them return `None` or a `Some` is found.

--- a/examples/mapper.rs
+++ b/examples/mapper.rs
@@ -98,7 +98,7 @@ async fn main() {
     // one thread is queueing up parent models to be received on the other end
     let receive_mapper = mapper.clone();
     let receive_task = tokio::task::spawn(async {
-        let mut mapper = receive_mapper;
+        let mapper = receive_mapper;
         for index in 0..10 {
             tokio::time::sleep(Duration::from_secs(1)).await;
             println!("receiving {}...", index);
@@ -140,7 +140,10 @@ async fn main() {
         }
     });
 
-    tokio::join!(receive_task, poll_task, send_task);
+    let result = tokio::join!(receive_task, poll_task, send_task);
+    result.0.expect("The receive task should join properly.");
+    result.1.expect("The receive task should join properly.");
+    result.2.expect("The receive task should join properly.");
 
     println!("Successful!");
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -220,6 +220,7 @@ macro_rules! split_merge_helper {
                     futures::join!($(self.[<$($field)*>].receive(input.clone())),*);
                 }
                 async fn send(&mut self) -> Option<std::sync::Arc<tokio::sync::Mutex<$to>>> {
+                    // TODO try other fields if None is returned
                     let next_send_field_index: usize;
                     {
                         let mut next_send_field_index_lock = self.next_send_field_index.lock().await;

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -5,8 +5,8 @@ pub trait ChainLink {
     type TInput;
     type TOutput;
 
-    async fn receive(&mut self, input: std::sync::Arc<std::sync::Mutex<Self::TInput>>);
-    async fn send(&mut self) -> Option<std::sync::Arc<std::sync::Mutex<Self::TOutput>>>;
+    async fn receive(&mut self, input: std::sync::Arc<tokio::sync::Mutex<Self::TInput>>);
+    async fn send(&mut self) -> Option<std::sync::Arc<tokio::sync::Mutex<Self::TOutput>>>;
     async fn poll(&mut self);
     //async fn chain(self, other: impl ChainLink) -> ChainLink;
 }
@@ -16,9 +16,9 @@ macro_rules! chain_link {
     ($type:ty => ($($property_name:ident: $property_type:ty),*), $receive_name:ident: $receive_type:ty => $output_type:ty, $map_block:block) => {
         paste::paste! {
             pub struct $type {
-                initializer: std::sync::Arc<std::sync::Mutex<[<$type Initializer>]>>,
-                input_queue: deadqueue::unlimited::Queue<std::sync::Arc<std::sync::Mutex<$receive_type>>>,
-                output_queue: deadqueue::unlimited::Queue<std::sync::Arc<std::sync::Mutex<$output_type>>>
+                initializer: std::sync::Arc<tokio::sync::Mutex<[<$type Initializer>]>>,
+                input_queue: deadqueue::unlimited::Queue<std::sync::Arc<tokio::sync::Mutex<$receive_type>>>,
+                output_queue: deadqueue::unlimited::Queue<std::sync::Arc<tokio::sync::Mutex<$output_type>>>
             }
 
             pub struct [<$type Initializer>] {
@@ -30,9 +30,9 @@ macro_rules! chain_link {
             impl $type {
                 pub fn new(initializer: [<$type Initializer>]) -> Self {
                     $type {
-                        initializer: std::sync::Arc::new(std::sync::Mutex::new(initializer)),
-                        input_queue: deadqueue::unlimited::Queue::<std::sync::Arc<std::sync::Mutex<$receive_type>>>::default(),
-                        output_queue: deadqueue::unlimited::Queue::<std::sync::Arc<std::sync::Mutex<$output_type>>>::default()
+                        initializer: std::sync::Arc::new(tokio::sync::Mutex::new(initializer)),
+                        input_queue: deadqueue::unlimited::Queue::<std::sync::Arc<tokio::sync::Mutex<$receive_type>>>::default(),
+                        output_queue: deadqueue::unlimited::Queue::<std::sync::Arc<tokio::sync::Mutex<$output_type>>>::default()
                     }
                 }
             }
@@ -48,23 +48,23 @@ macro_rules! chain_link {
                 type TInput = $receive_type;
                 type TOutput = $output_type;
 
-                async fn receive(&mut self, input: std::sync::Arc<std::sync::Mutex<$receive_type>>) -> () {
+                async fn receive(&mut self, input: std::sync::Arc<tokio::sync::Mutex<$receive_type>>) -> () {
                     self.input_queue.push(input);
                 }
-                async fn send(&mut self) -> Option<std::sync::Arc<std::sync::Mutex<$output_type>>> {
+                async fn send(&mut self) -> Option<std::sync::Arc<tokio::sync::Mutex<$output_type>>> {
                     self.output_queue.try_pop().map(|element| {
                         element.into()
                     })
                 }
                 async fn poll(&mut self) {
                     if let Some($receive_name) = self.input_queue.try_pop() {
-                        let received: &mut $receive_type = &mut $receive_name.lock().unwrap();
-                        let initializer: &mut [<$type Initializer>] = &mut self.initializer.lock().unwrap();
+                        let received: &mut $receive_type = &mut (*$receive_name.lock().await);
+                        let initializer: &mut [<$type Initializer>] = &mut (*self.initializer.lock().await);
                         let $receive_name = [<_ $type Input>] {
                             received,
                             initializer
                         };
-                        self.output_queue.push(std::sync::Arc::new(std::sync::Mutex::new($map_block)));
+                        self.output_queue.push(std::sync::Arc::new(tokio::sync::Mutex::new($map_block)));
                     } 
                 }
             }
@@ -146,10 +146,10 @@ macro_rules! chain_remaining {
                 type TInput = $from;
                 type TOutput = $to;
 
-                async fn receive(&mut self, input: std::sync::Arc<std::sync::Mutex<$from>>) -> () {
+                async fn receive(&mut self, input: std::sync::Arc<tokio::sync::Mutex<$from>>) -> () {
                     self.$first_name.receive(input).await
                 }
-                async fn send(&mut self) -> Option<std::sync::Arc<std::sync::Mutex<$to>>> {
+                async fn send(&mut self) -> Option<std::sync::Arc<tokio::sync::Mutex<$to>>> {
                     self.$last_name.send().await
                 }
                 async fn poll(&mut self) {
@@ -159,17 +159,11 @@ macro_rules! chain_remaining {
                         if let Some(next_input) = next_input {
                             self.[<$($field)*>].receive(next_input).await;
                         }
-                        else {
-                            return;
-                        }
                         self.[<$($field)*>].poll().await;
                         let next_input = self.[<$($field)*>].send().await;
                     )*
                     if let Some(next_input) = next_input {
                         self.$last_name.receive(next_input).await;
-                    }
-                    else {
-                        return;
                     }
                     self.$last_name.poll().await;
                 }
@@ -203,7 +197,7 @@ macro_rules! split_merge_helper {
                 $(
                     [<$($field)*>]: $field_type,
                 )*
-                next_send_field_index: std::sync::Mutex<usize>
+                next_send_field_index: tokio::sync::Mutex<usize>
             }
 
             impl $name {
@@ -212,7 +206,7 @@ macro_rules! split_merge_helper {
                         $(
                             [<$($field)*>]: $field_type::new([<$($field)* _initializer>]),
                         )*
-                        next_send_field_index: std::sync::Mutex::new(0)
+                        next_send_field_index: tokio::sync::Mutex::new(0)
                     }
                 }
             }
@@ -222,13 +216,13 @@ macro_rules! split_merge_helper {
                 type TInput = $from;
                 type TOutput = $to;
 
-                async fn receive(&mut self, input: std::sync::Arc<std::sync::Mutex<$from>>) -> () {
+                async fn receive(&mut self, input: std::sync::Arc<tokio::sync::Mutex<$from>>) -> () {
                     futures::join!($(self.[<$($field)*>].receive(input.clone())),*);
                 }
-                async fn send(&mut self) -> Option<std::sync::Arc<std::sync::Mutex<$to>>> {
+                async fn send(&mut self) -> Option<std::sync::Arc<tokio::sync::Mutex<$to>>> {
                     let next_send_field_index: usize;
                     {
-                        let mut next_send_field_index_lock = self.next_send_field_index.lock().unwrap();
+                        let mut next_send_field_index_lock = self.next_send_field_index.lock().await;
                         next_send_field_index = *next_send_field_index_lock;
                         if next_send_field_index + 1 == ($count) {
                             *next_send_field_index_lock = 0;

--- a/src/test.rs
+++ b/src/test.rs
@@ -140,4 +140,23 @@ mod test {
             }
         }
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn split_to_two_chain_links() {
+        chain_link!(StringToInt, input: String => i32, {
+            if input.received.as_str() == "test" {
+                1
+            }
+            else {
+                2
+            }
+        });
+        chain_link!(StringPrint, input: String => (), {
+            println!("{}", input.received);
+        });
+        split!(Test, String, (StringToInt => i32, StringPrint => ()));
+
+        let test = Test::new(StringToIntInitializer { }, StringPrintInitializer { });
+        
+    }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod test {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc};
+    use tokio::sync::Mutex;
     use crate::chain::ChainLink;
 
     #[derive(Debug, PartialEq)]
@@ -49,7 +50,7 @@ mod test {
         let response = test.send().await;
         match response {
             Some(response) => {
-                assert_eq!("second", response.lock().unwrap().as_str());
+                assert_eq!("second", response.lock().await.as_str());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -65,7 +66,7 @@ mod test {
         let response = test.send().await;
         match response {
             Some(response) => {
-                assert_eq!("test", Arc::try_unwrap(response).unwrap().into_inner().unwrap().as_str());
+                assert_eq!("test", Arc::try_unwrap(response).unwrap().into_inner().as_str());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -82,7 +83,7 @@ mod test {
         let response = chain_test.send().await;
         match response {
             Some(response) => {
-                assert_eq!(SomeInput::Second, Arc::try_unwrap(response).unwrap().into_inner().unwrap());
+                assert_eq!(SomeInput::Second, Arc::try_unwrap(response).unwrap().into_inner());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -99,7 +100,7 @@ mod test {
         let response = triple_test.send().await;
         match response {
             Some(response) => {
-                assert_eq!("first", response.lock().unwrap().as_str());
+                assert_eq!("first", response.lock().await.as_str());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -116,7 +117,7 @@ mod test {
         let response = chain_to_chain.send().await;
         match response {
             Some(response) => {
-                assert_eq!("first", response.lock().unwrap().as_str());
+                assert_eq!("first", response.lock().await.as_str());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -133,7 +134,7 @@ mod test {
         let response = chain_to_chain_to_link.send().await;
         match response {
             Some(response) => {
-                assert_eq!(SomeInput::Second, Arc::try_unwrap(response).unwrap().into_inner().unwrap());
+                assert_eq!(SomeInput::Second, Arc::try_unwrap(response).unwrap().into_inner());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -163,7 +164,7 @@ mod test {
         let response = test.send().await;
         match response {
             Some(response) => {
-                assert_eq!(1, Arc::try_unwrap(response).unwrap().into_inner().unwrap());
+                assert_eq!(1, Arc::try_unwrap(response).unwrap().into_inner());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -173,7 +174,7 @@ mod test {
         let response = test.send().await;
         match response {
             Some(response) => {
-                assert_eq!(0, Arc::try_unwrap(response).unwrap().into_inner().unwrap());
+                assert_eq!(0, Arc::try_unwrap(response).unwrap().into_inner());
             },
             None => {
                 panic!("Unexpected None response.");
@@ -183,7 +184,7 @@ mod test {
         let response = test.send().await;
         match response {
             Some(response) => {
-                panic!("Unexpected Some response with value {}.", response.lock().unwrap());
+                panic!("Unexpected Some response with value {}.", response.lock().await);
             },
             None => {
                 // expected path


### PR DESCRIPTION
With the new `split_merge!` macro, it is now possible to easily parallelize `ChainLink` instances.